### PR TITLE
fix: prevent smartConfigure from overwriting offset bytes.

### DIFF
--- a/cpp/screen.cpp
+++ b/cpp/screen.cpp
@@ -160,9 +160,9 @@ public:
 
     // SER pin (or first bit of second HC) is orientation
     if (hc & 0x0010)
-      *cfg0 = 0x80;
+      *cfg0 |= 0x80;
     else
-      *cfg0 = 0x40;
+      *cfg0 |= 0x40;
 
     uint32_t configId = (hc & 0xe0) >> 5;
 


### PR DESCRIPTION
Hi, 
as mentioned in https://github.com/microsoft/pxt-arcade/issues/6438 changing the CFG0 bytes does not lead to the desired change in e.g. the offset values for the display when the display type is set to 4242 (Smart Display). I could trace this down to the smartConfigure function, in which in line 173 or 175 the content of the cfg0 variable is currently rewritten to either 0x80 or 0x40. Since the smartConfigure function is called before the offset values are read out (line 82), the rewriting leads to an erasure of the offset values.
The proposed fix only sets the relevant bits, leaving cfg0 intact.